### PR TITLE
yarn から npm への移行予告を追加  4_clone-repository.md

### DIFF
--- a/translation/4_clone-repository.md
+++ b/translation/4_clone-repository.md
@@ -1,4 +1,5 @@
 # 4. fork リポジトリを clone する
+  ## （2025年12月1日(UTC)に、[yarn から npm への移行](https://github.com/mdn/content/pull/42048)が予定されています）
 
 ## 初めてリポジトリを clone する場合 {#first}
 


### PR DESCRIPTION
relates https://github.com/mozilla-japan/mdn-translation-guide/issues/29